### PR TITLE
Adding Design Doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ local.properties
 
 # Log/OS Files
 *.log
+.DS_Store
+**/.DS_Store
+**/**/.DS_Store
 
 # Android Studio generated files and folders
 captures/

--- a/docs/DesignDoc.es.md
+++ b/docs/DesignDoc.es.md
@@ -1,0 +1,161 @@
+## Android Dev Perú App
+
+### Introducción
+Este proyecto involucra las últimas tecnologías relacionadas con el desarrollo de apps Android y Kotlin. Es decir, aquí encontrarás funciones desarrolladas con Jetpack Compose, Kotlin Multiplatform, Gradle, utilizando una arquitectura modular y en capas, testing y todas las habilidades MAD (desarrollo moderno de Android) relacionadas.
+
+Los organizadores de la comunidad comenzarán a darle vida al proyecto para definir la arquitectura base y la hoja de ruta de características y estará abierto a Pull Requests.
+
+### Principales funcionalidades
+El proyecto contendrá los siguientes _features_:
+1. Eventos
+   - 1.1 Mostrar la lista de eventos (MeetUps y talleres/workshops) ordenados por fecha: del más reciente al más antiguo. Además, el usuario podrá filtrar eventos por tipo, mes, año, etc.
+   - 1.2 Detalles del evento para mostrar toda la información relacionada de un evento: título, descripción, oradores, ubicación, si será _online_ o se llevará a cabo en una dirección física, lista de asistentes, etc.
+   - 1.3 Registrar asistencia a un evento: los usuarios podrán registrarse a un evento.
+2. Información de la comunidad
+   - 2.1 Información sobre la comunidad: redes sociales, enlaces útiles, historial, etc.
+   - 2.2 Organizadores: lista de los organizadores actuales y una pequeña descripción de cada perfil.
+3. Autenticación
+   - 3.1 Inicio de sesión con Google y Apple: requerido para tener la aplicación disponible en AppStore (algún día). No será obligatorio iniciar sesión en la aplicación para navegar por ella. Sin embargo, podría ser necesario para registrar la asistencia a un evento.
+
+**MVP (Producto Mínimo Viable)**
+
+En la primera versión, vamos a priorizar las siguientes características:
+
+- 1.1 Lista de eventos (sin filtrar)
+- 1.2 Detalles de eventos (sin lista de asistentes)
+- 2.1 Pantalla con información de la comunidad
+
+
+---
+
+
+### Arquitectura
+Vamos a implementar una arquitectura modular y en capas. Sin embargo, para la primera iteración, mantendremos todo el código en un solo módulo Gradle (_shared_) y allí dividiremos el código en paquetes.
+
+**Capa de dominio o Lógica de Negocio**
+
+Los siguientes modelos de datos estarán relacionados con la lógica principal de la app:
+```
+class Event
+ - String id
+ - String title
+ - String description
+ - Date createdAt
+ - Date lastUpdate
+ - Date dateTime
+ - * List<Attendee> attendees
+ - String eventBannerUrl
+ - Speaker speaker
+ - EventType eventType
+ - EventLocation location
+ - String addressInfo
+
+enum EventType: meetup, workshop
+
+enum EventLocation: online, inPerson
+
+
+interface EventsRepository
+ - List<Event> getLastEvents(int offset = 0)
+ - Event getEventInfo(String eventId)
+
+
+
+--- not part of MVP ---
+
+class Attendee
+ - String id
+ - String name
+ - AttendeeStatus status
+ - Date statusDate
+ - String profilePic
+
+enum AttendeeStatus: invited, accepted, rejected, unknown
+
+class UserAccount
+ - String id
+ - String createdAt
+ - String email
+ - List<Platform> platforms
+ - Boolean acceptsNotificationEvents
+
+class UserProfile
+ - String accountId
+ - String name
+ - String lastName
+ - String profilePicUrl
+ - List<String> attendedEventsIds
+
+
+Other repository interfaces to be defined later.
+
+```
+
+_Notar el uso de la nomenclatura camel case._
+
+_*La clase Event no tendrá la lista de asistentes como atributo para el MVP_
+
+
+
+**Capa de datos**
+
+Para empezar no vamos a consumir ninguna fuente de datos externa, aplicaremos el patrón repositorio. La siguiente es la capa de datos estructurada sugerida:
+```
+- domain
+ - repository
+
+- data
+ - repository
+   - EventsRepositoryImpl
+ - dataSource
+   - LocalDataSource (implementación directa)
+   - RemoteDataSource (implementación directa, vacía)
+```
+_Tenga en cuenta que las fuentes de datos serán implementaciones que se inyectarán en `EventsRepositoryImpl` ya que vamos a tener (en el MVP) solo una fuente de datos._
+
+
+
+**Capa de Presentación o UI**
+
+Vamos a utilizar Compose Multiplatform e implementar los patrones de diseño Unidirectional Data Flow y Model View ViewModel.
+La estructura debe tener:
+```
+- core -> para definir el tema (fuentes, colores, etc) y vistas reutilizables (botones, campos de texto, etc).
+- feature-package -> tendremos solo dos por ahora: events y community
+```
+
+### Tech Stack
+Como ya imaginarás el tech stack estará conformado por:
+- Kotlin Multiplatform
+- Compose Multiplatform
+- Kotlin 1.9
+- Kamel 0.9.0 para la carga de imagenes
+- Navigation -> TBD
+
+
+---
+
+### Otros detalles
+
+**Diseño**
+
+Intentamos utilizar GalileoAi pero aún está en desarrollo y cerrado a todas las personas. Podríamos simplemente proponer un diseño mientras lo desarrollamos. Es **importante definir la temática: colores, estilos de texto, etc**.
+
+
+**Para contribuir**
+
+1. Por favor, escribe tus Pull Requests brindando una breve descripción, cuáles fueron los principales cambios y cómo o por qué hiciste lo que hiciste. Si se modifica la interfaz de usuario, proporcione una captura de pantalla de cómo se veía antes y cómo se ve ahora. Más adelante definiremos una plantilla para los Pull Requests.
+
+2. El desarrollo se mueve gracias a un Proyecto Github. Por favor, lea atentamente todas las tareas restantes y no dude en proponer nuevas tareas que estén enlazadas a issues de Github.
+
+3. Las etiquetas (labels) siempre las ponen los mantenedores/organizadores.
+
+4. Si no eres parte del equipo de la organización, crea un _fork_ del repositorio y agrega tus contribuciones a través de un Pull Request.
+
+4. Para nuevos _features_, cree una rama `feature/featureName`. Para fixes/correcciones: `bugfix/taskCode` o `bugfix/fixName`.
+
+
+ 
+
+
+

--- a/docs/DesignDoc.md
+++ b/docs/DesignDoc.md
@@ -1,0 +1,161 @@
+## Android Dev Perú App
+
+### Introduction
+This project involves the lastest technologies related to Android and Kotlin development. That is, you'll find here features developed using Jetpack Compose, Kotlin Multiplatform, Gradle, a modular and layered architecture, testing, and all related MAD (Modern Android Development) skills.
+
+The project will start being maintained by the community organizers to define the base architecture and rfeatures roadmap and will be open to pull requests.
+
+
+### Main Features
+The project will contain the following features:
+1. Events
+  - 1.1 Show list of events (MeetUps and workshops) ordered by dated: from the latest to the oldest. Moreover, user will be able to filter events by type, month, year, etc.
+  - 1.2 Event details to show all related information of an event: title, descripcion, speakers, location, if it's online or will take place in a physical address, list of attendees, etc.
+  - 1.3 Register assistance to an event: users will be able to register to an event.
+2. Community information
+  - 2.1 Information about the community: social networks, useful links, history, etc.
+  - 2.2 Organizers: list of the current organizers and a little profile description.
+3. Authentication
+  - 3.1 Login with Google and Apple: required in order to have the app available for AppStore (some day). It is not mandatory to log into the app to navigate through it. However, could be required in order to register attendance to an event.
+
+**MVP (Minimal Viable Product)**
+
+On the first version, we are going to prioritize the following features:
+
+- 1.1 Events list (without filtering)
+- 1.2 Events details (without attendants list)
+- 2.1 Screen with community information
+
+
+---
+
+
+### Architecture
+We are going to implement a layered and modular architecture. However, for the first iteration, we are going to keep all the code in one single Gradle module (shared) and there, divide the code into packages.
+
+
+**Domain layer**
+
+The following data models are going to be related to the domain logic:
+```
+class Event
+ - String id
+ - String title
+ - String description
+ - Date createdAt
+ - Date lastUpdate
+ - Date dateTime
+ - * List<Attendee> attendees
+ - String eventBannerUrl
+ - Speaker speaker
+ - EventType eventType
+ - EventLocation location
+ - String addressInfo
+
+enum EventType: meetup, workshop
+
+enum EventLocation: online, inPerson
+
+
+interface EventsRepository
+ - List<Event> getLastEvents(int offset = 0)
+ - Event getEventInfo(String eventId)
+
+
+
+--- not part of MVP ---
+
+class Attendee
+ - String id
+ - String name
+ - AttendeeStatus status
+ - Date statusDate
+ - String profilePic
+
+enum AttendeeStatus: invited, accepted, rejected, unknown
+
+class UserAccount
+ - String id
+ - String createdAt
+ - String email
+ - List<Platform> platforms
+ - Boolean acceptsNotificationEvents
+
+class UserProfile
+ - String accountId
+ - String name
+ - String lastName
+ - String profilePicUrl
+ - List<String> attendedEventsIds
+
+
+Otras interfaces de repositorios serán definidas después.
+
+```
+
+_Notice the use of camel case as naming convention._
+
+_*The Event data class won't have the list of attendees as an attribute for the MVP_
+
+
+
+**Data layer**
+
+Since we are not going to consume any external data source to begin, we should apply the Repository Pattern properly. The following is the data layer structured suggested:
+```
+- domain
+ - repository
+
+- data
+ - repository
+   - EventsRepositoryImpl
+ - dataSource
+   - LocalDataSource (direct implementation)
+   - RemoteDataSource (direct implementation, empty)
+```
+_Notice that the data sources are going to be implementations to be injected into the `EventsRepositoryImpl` since we are going to have (in the MVP) only one data source._
+
+
+
+**Presentation Layer**
+
+We are going to use Compose Multiplatform and implement the Unidirectional Data Flow and Model View ViewModel design patterns.
+The structure should have:
+```
+- core -> to define theming and reusable composables (buttons, fields, etc)
+- feature-package -> we are going to have only two: events and community
+```
+
+### Tech Stack
+As you might already know the stack is going to be conformed by:
+- Kotlin Multiplatform
+- Compose Multiplatform
+- Kotlin 1.9
+- Kamel 0.9.0 for image loading
+- Navigation -> TBD
+
+
+---
+
+### Other details
+
+**Design**
+
+We tried to use GalileoAi but it's still in development and closed to all people. We could just propose a design while developing. It's **important to define de theming: colors, text styles, etc**.
+
+
+**To contribute**
+1. Please, write your Pull Requests providing a brief description, what were the main changes and how or why did you did what you did. If UI is altered, please provide a screenshot of how it used to look and how it looks now. We are going to define a Pull Request template later.
+
+2. The development moves thanks to a Github Project. Please, read carefully all the reamining tasks and feel free to propouse new tasks linking the Github Issue.
+
+3. Labels are always put by maintainers.
+4. If you are not part of the organization team, please fork the repository and add your contributions through a Pull Request.
+
+4. For new features, create a `feature/featureName` branch. For fixes: `bugfix/taskCode` or `bugfix/fixName`.
+
+
+ 
+
+
+

--- a/docs/README.es.md
+++ b/docs/README.es.md
@@ -1,0 +1,8 @@
+### Android Dev Perú App - Documentación
+---
+
+En esta carpeta, podrás encontrar la documentación relacionada al proyecto de código abierto de la aplicación de la comunidad Android Dev Perú. Esto incluye documentos de diseño de software, definición de funcionalidades y otros archivos relacionados.
+
+Puedes empezar accediendo al archivo _DesignDoc.es.md_.
+
+La documentacións erá escrita tanto en inglés como en español.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,8 @@
+### Android Dev Perú App documentation
+---
+
+In this folder, you'll be able find the documentation related to the Android Dev Perú App project. This includes design docs, feature definitions and other related files.
+
+You can start by reading the _DesignDoc.md_ (or _DesignDoc.es.md_).
+
+Documentation will be written in both English and Spanish.


### PR DESCRIPTION
Adding markdown files in a new _Docs_ folder.

- README →  for a brief description of the Docs folder.
- DesignDoc →  a proposal design doc for the app. Please, feel free to add or discuss suggestions.

All available in English and Spanish.

In addition, I modified the root _.gitignore_ file in order to ignore MacOs unnecessary hidden file _DS_Store_.